### PR TITLE
fix(deploy): btcd healthcheck + mongo start_period gate + incident-re…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,10 @@ services:
     container_name: go-vsc-node # what to label the container for docker ps
     restart: always # restart if failed, until we stop it ourselves
     depends_on:
-      - mongo
-      - btcd
+      mongo:
+        condition: service_healthy
+      btcd:
+        condition: service_healthy
     networks:
       - go-vsc-node
     ports:
@@ -56,6 +58,11 @@ services:
       interval: 10s
       retries: 5
       timeout: 5s
+      # AF-2: give mongod time for journal replay on cold boot before the
+      # service_healthy gate trips. Without this, go-vsc-node (which now waits
+      # on `mongo: condition: service_healthy`, see C9) bricks cold-boot if
+      # journal replay takes longer than interval*retries (~50s).
+      start_period: 60s
     logging:
       driver: "json-file"
       options:
@@ -83,6 +90,22 @@ services:
     container_name: vsc-btcd
     command: -rpcuser=vsc-node-user -rpcpassword=vsc-node-pass -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0 -prune=550 -dbcache=2048 -server=1 -listen=1
     restart: always
+    # NOTE: the -rpcuser / -rpcpassword in the healthcheck below MUST stay in sync
+    # with the -rpcuser / -rpcpassword in the `command:` above. If the BTC RPC
+    # credentials are rotated (see CRIT-6 remediation), update BOTH places in the
+    # same commit or the healthcheck will fail with HTTP 401 and go-vsc-node will
+    # never start (depends_on: btcd: condition: service_healthy).
+    healthcheck:
+      test:
+        - "CMD"
+        - "bitcoin-cli"
+        - "-rpcuser=vsc-node-user"
+        - "-rpcpassword=vsc-node-pass"
+        - "getblockchaininfo"
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
     volumes:
       - ./.btc-data:/home/bitcoin/.bitcoin
     logging:


### PR DESCRIPTION
## Summary
Operational hardening to the deployment compose + README, from the Magi mainnet pre-liquidity audit.

| Finding | Fix |
|---|---|
| **VD-L-BTCDHEALTH** | btcd had no healthcheck (mongo did), so go-vsc-node could start against a not-ready btcd. Added a btcd healthcheck (`bitcoin-cli getblockchaininfo`, `interval 15s / timeout 10s / retries 5 / start_period 30s`) and upgraded go-vsc-node's `depends_on` for **both** mongo and btcd to `condition: service_healthy`. `getblockchaininfo` responds during IBD, so the gate passes on RPC-up (no deadlock). |
| **AF-2** (audit-of-fixes) | The new `mongo: condition: service_healthy` gate exposed that the **mongo healthcheck had no `start_period`** → a cold-boot journal replay (>50s) would block node startup forever. Added `start_period: 60s` to the mongo healthcheck. |
| **VD-L-README** | No incident-response procedure. Added an Incident Response section (key compromise, chain halt, btcd not syncing, stuck withdrawal, bad auto-update rollback, security contact). |

## ⚠ Note — CRIT-6 coupling
The btcd healthcheck uses `-rpcuser`/`-rpcpassword` that must stay in sync with the btcd `command:` flags. **CRIT-6** (hardcoded BTC RPC creds) is Milo/tibfox's — when that's fixed, the healthcheck creds must be templated from the same source (both updated in the same commit), or the healthcheck 401s and the node never starts. (This PR does not touch/worsen CRIT-6.)

## Testing
- `docker compose config -q` validates cleanly (no containers started); `bitcoin-cli getblockchaininfo` confirmed present in `bitcoin/bitcoin:29.3`; mongo renders `start_period: 1m0s`.
- No code, no binaries, no tests (infra/docs only).

## Deploy
Operators must `git pull` + `docker compose down && docker compose up -d` to pick up compose changes (watchtower does **not** deliver them).

## Files
`docker-compose.yml`, 

