### PR TITLE
VD-M3 — bind GraphQL API to loopback, not all interfaces

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,12 @@ services:
     networks:
       - go-vsc-node
     ports:
-      - 8080:8080
+      # review7 VD-M3: bind the GraphQL API to loopback only. Publishing it on
+      # 0.0.0.0 exposed the node's GQL (state/query surface) to the public
+      # internet; front it with an authenticated reverse proxy if external
+      # access is needed. The p2p ports below stay published — they must be
+      # reachable by other validators.
+      - 127.0.0.1:8080:8080
       - 10720:10720
       - 10720:10720/udp
     environment:


### PR DESCRIPTION
This pull request makes a security improvement to the `docker-compose.yml` configuration by restricting the GraphQL API to be accessible only from the local machine, rather than exposing it to the public internet. This helps prevent unauthorized external access to the node's GraphQL interface.

Security and network configuration:

* Changed the `services` section in `docker-compose.yml` to bind the GraphQL API port (`8080`) to `127.0.0.1` (loopback interface) instead of `0.0.0.0`, ensuring the API is only accessible locally and not exposed publicly.