### PR TITLE
VD-H1: require MongoDB authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# VD-H1: MongoDB credentials. Copy to `.env` and set a strong, unique password.
+# The DB is bound to 127.0.0.1 only, but authentication closes off any local
+# process / other container on the host from reading or tampering with chain
+# state. MONGO_PASSWORD is REQUIRED — compose refuses to start without it.
+MONGO_USER=vsc_node
+MONGO_PASSWORD=
+
+# Optional: disable Watchtower auto-updates (default true).
+# AUTO_UPDATE=false

--- a/README.md
+++ b/README.md
@@ -9,12 +9,25 @@ This repository hosts the Docker Compose file necessary for deploying the VSC no
 2. `git clone https://github.com/vsc-eco/vsc-deployment`
    Clone this repository as a normal user (not root/admin) to a desired location. It's crucial to ensure the Docker user has write permissions in the directory where you plan to initiate the Docker Compose file.
 
-3. `docker compose run init`
+3. `cp .env.example .env` and set a strong, unique `MONGO_PASSWORD`.
+   MongoDB now requires authentication (VD-H1): the database stores all chain
+   state, and an unauthenticated instance is readable/writable by any other
+   process or container on the host. Compose refuses to start until
+   `MONGO_PASSWORD` is set.
+
+   > **Upgrading an existing node** whose `./data/vsc-db` was created before
+   > authentication was enabled: the `MONGO_INITDB_ROOT_*` variables only create
+   > the user on a *fresh* data directory, so create it once manually —
+   > `docker compose up -d mongo`, then
+   > `docker exec -it mongo_vsc mongosh admin --eval 'db.createUser({user:process.env.MONGO_USER,pwd:process.env.MONGO_PASSWORD,roles:[{role:"root",db:"admin"}]})'`
+   > — and restart the stack. Fresh installs need no manual step.
+
+4. `docker compose run init`
    Initialize the configuration files
 
-4. Edit the config file located at `./data/config/identityConfig.json` and be sure to add in your Hive username and active key
+5. Edit the config file located at `./data/config/identityConfig.json` and be sure to add in your Hive username and active key
 
-5. `docker compose up -d`
+6. `docker compose up -d`
    Start the Docker containers. This will add a GraphQL server on port 8080, a MongoDB instance on port 27021, and a libp2p connection on port 10720.
 
 ### Starting Up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     image: vscnetwork/go-vsc-node:main
     command: ./vsc-node --init
     environment:
-      - MONGO_URL=mongodb://mongo:27017
+      # VD-H1: authenticated MongoDB connection (see mongo service + .env.example).
+      - MONGO_URL=mongodb://${MONGO_USER:-vsc_node}:${MONGO_PASSWORD:?set MONGO_PASSWORD in .env}@mongo:27017/?authSource=admin
     depends_on:
       - mongo
     networks:
@@ -26,7 +27,8 @@ services:
       - 10720:10720
       - 10720:10720/udp
     environment:
-      - MONGO_URL=mongodb://mongo:27017
+      # VD-H1: authenticated MongoDB connection (see mongo service + .env.example).
+      - MONGO_URL=mongodb://${MONGO_USER:-vsc_node}:${MONGO_PASSWORD:?set MONGO_PASSWORD in .env}@mongo:27017/?authSource=admin
     volumes:
       - ./data:/home/app/app/data
     logging:
@@ -45,6 +47,14 @@ services:
     image: mongo:8.0.17
     pull_policy: always
     restart: always
+    # VD-H1: enable authentication. Setting these on the official image both
+    # creates the root user (on first init of an EMPTY data dir) and turns on
+    # --auth, so the instance is no longer open to anyone who can reach it.
+    # NOTE: these only initialise a FRESH ./data/vsc-db; an existing un-authed
+    # volume must have the user created manually (see README) before auth works.
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_USER:-vsc_node}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:?set MONGO_PASSWORD in .env}
     ports:
       - 127.0.0.1:27021:27017
     networks:


### PR DESCRIPTION
This pull request introduces mandatory authentication for the MongoDB instance used in the deployment, enhancing security by requiring a username and password for all database access. The setup instructions and Docker Compose configuration have been updated to reflect this change, and guidance is provided for both fresh installs and upgrades of existing nodes.

**Security: MongoDB authentication**

* MongoDB now requires authentication using environment variables `MONGO_USER` and `MONGO_PASSWORD`, which must be set in the `.env` file. Compose will refuse to start without a password. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L7-R8) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L29-R31) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R50-R57) [[4]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR1-R9)
* The `mongo` service in `docker-compose.yml` is configured to initialize the root user and enable authentication on fresh data directories. For existing data, manual user creation is required, with instructions added to the `README.md`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R50-R57) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12-R30)

**Documentation and setup process**

* The `.env.example` file is added with explanatory comments and required variables for MongoDB credentials.
* The `README.md` is updated to include new setup steps for copying `.env.example`, setting the MongoDB password, and handling upgrades from unauthenticated to authenticated databases.