### PR TITLE
Consolidates #12, #15, #17 (deployment hardening + multi-core sync)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# VD-H1: MongoDB credentials. Copy this file to `.env` and set a strong,
+# unique password. The DB is bound to 127.0.0.1 only, but authentication closes
+# it off from any other local process / container on the host that could
+# otherwise read or tamper with chain state. MONGO_PASSWORD is REQUIRED —
+# compose refuses to start without it.
+#
+# IMPORTANT: the password is interpolated raw into the MongoDB connection URI
+# (mongodb://user:PASSWORD@mongo:27017/...), so it MUST be URL-safe. Avoid the
+# characters  @ : / ? # [ ] %  (or percent-encode them, e.g. `@` -> `%40`).
+# Sticking to letters, digits and  - _ . ~  is the safe choice.
+MONGO_USER=vsc_node
+MONGO_PASSWORD=
+
+# Optional: disable Watchtower auto-updates (default true).
+# AUTO_UPDATE=false

--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ To launch the node, execute `docker compose up -d` from the command line (or `do
 
 For real-time log observation, use `docker logs go-vsc-node -f`.
 
+### Faster initial sync (multi-core machines)
+
+The first run has to sync the Bitcoin block chain. btcd's default cache is
+small, and inside a container its CPU auto-detection often under-counts the
+cores it can use. On a multi-core host you can speed up the initial sync with
+the `multi-core-docker-compose.yml` override, which raises `-dbcache` and pins
+btcd's script-verification threads (`-par`):
+
+```
+docker compose -f docker-compose.yml -f multi-core-docker-compose.yml up -d
+```
+
+It only overrides btcd's `command:`; everything else is inherited from the
+base file. Tune `-par` / `-dbcache` to your machine in that file.
+
 ### Maintenance
 
 The node is designed to self-update as necessary. However, on rare occasions, the deployment configuration may require manual updates not covered by automatic updates. Should such a situation arise, we will inform the community through our usual communication channels [discord](http://discord.gg/yvGXZsQTU6) and [twitter](https://twitter.com/vsc_eco).

--- a/README.md
+++ b/README.md
@@ -38,6 +38,54 @@ docker compose -f docker-compose.yml -f multi-core-docker-compose.yml up -d
 It only overrides btcd's `command:`; everything else is inherited from the
 base file. Tune `-par` / `-dbcache` to your machine in that file.
 
+### Incident Response
+
+A short runbook for operators. When in doubt, capture logs first
+(`docker logs --since 1h go-vsc-node > incident.log 2>&1` — the `2>&1` captures
+stderr too, which a bare `>` would drop) and reach the core team on
+[discord](http://discord.gg/yvGXZsQTU6) before taking destructive action.
+
+- **Suspected key compromise** (the active key in
+  `./data/config/identityConfig.json` leaked). Stop the node
+  (`docker compose down`), rotate the account's **active key** on Hive L1
+  (this requires the account's owner key), update `identityConfig.json` with
+  the new key, then
+  `docker compose up -d`. Notify the team so other witnesses are aware. Treat
+  the old key as burned.
+
+- **Chain halt / node stuck** (no new blocks in the logs). Check
+  `docker logs go-vsc-node -f` for panics and peer count. A restart
+  (`docker compose restart go-vsc-node`) clears most transient stalls. If the
+  Mongo state looks corrupt, do **not** wipe `./data/vsc-db` blindly — ask the
+  team; a full resync is slow and a bad restore can leave you on a diverged
+  state.
+
+- **btcd not syncing.** Inspect `docker logs vsc-btcd -f` and
+  `docker exec vsc-btcd bitcoin-cli -rpcuser=vsc-node-user -rpcpassword=vsc-node-pass getblockchaininfo`
+  (watch `blocks` vs `headers` and `verificationprogress`). No peers → check
+  outbound connectivity; slow IBD → use the multi-core override above. Because
+  go-vsc-node gates on `btcd: service_healthy`, a wedged btcd shows up as
+  go-vsc-node never starting.
+
+- **Stuck withdrawal / action.** These are L2 protocol state, not something to
+  fix by editing Mongo. Record the affected transaction id and account, grab
+  the relevant log window, and report to the team — manual DB surgery on
+  consensus state can desync your node from the network.
+
+- **Bad auto-update (rollback).** Watchtower tracks the `:main` tag, so a bad
+  push can roll forward automatically. To pin and roll back: set
+  `AUTO_UPDATE=false` (stops Watchtower touching the containers), find the
+  last-good image with `docker images --digests vscnetwork/go-vsc-node`, pin
+  that digest in `docker-compose.yml` (e.g. `image:
+  vscnetwork/go-vsc-node@sha256:...`), then
+  `docker compose up -d --force-recreate go-vsc-node`. Re-enable auto-update
+  once a fixed image is published.
+
+- **Security contact / disclosure.** Report vulnerabilities **privately** to
+  the core team via discord — do not post exploitable details in public
+  channels. We follow responsible disclosure and will coordinate a fix and
+  rollout window with operators.
+
 ### Maintenance
 
 The node is designed to self-update as necessary. However, on rare occasions, the deployment configuration may require manual updates not covered by automatic updates. Should such a situation arise, we will inform the community through our usual communication channels [discord](http://discord.gg/yvGXZsQTU6) and [twitter](https://twitter.com/vsc_eco).

--- a/README.md
+++ b/README.md
@@ -9,12 +9,29 @@ This repository hosts the Docker Compose file necessary for deploying the VSC no
 2. `git clone https://github.com/vsc-eco/vsc-deployment`
    Clone this repository as a normal user (not root/admin) to a desired location. It's crucial to ensure the Docker user has write permissions in the directory where you plan to initiate the Docker Compose file.
 
-3. `docker compose run init`
+3. `cp .env.example .env` and set a strong, unique `MONGO_PASSWORD`.
+   MongoDB now requires authentication (VD-H1): the database stores all chain
+   state, and an unauthenticated instance is readable/writable by any other
+   process or container on the host. Compose refuses to start until
+   `MONGO_PASSWORD` is set, and the password must be **URL-safe** (it is
+   interpolated into the connection URI — see `.env.example`).
+
+   > **Upgrading an existing node** whose `./data/vsc-db` was created before
+   > authentication was enabled: `MONGO_INITDB_ROOT_*` only seeds the user on a
+   > *fresh* data directory, so create it once manually — start mongo with
+   > `docker compose up -d mongo`, wait until it is healthy
+   > (`docker inspect --format '{{.State.Health.Status}}' mongo_vsc`), then
+   > `docker exec -it mongo_vsc mongosh admin --eval 'db.createUser({user:process.env.MONGO_INITDB_ROOT_USERNAME,pwd:process.env.MONGO_INITDB_ROOT_PASSWORD,roles:[{role:"root",db:"admin"}]})'`
+   > — then `docker compose down && docker compose up -d`. (Those env vars exist
+   > inside the `mongo_vsc` container; `MONGO_USER`/`MONGO_PASSWORD` do not.)
+   > Fresh installs need no manual step.
+
+4. `docker compose run init`
    Initialize the configuration files
 
-4. Edit the config file located at `./data/config/identityConfig.json` and be sure to add in your Hive username and active key
+5. Edit the config file located at `./data/config/identityConfig.json` and be sure to add in your Hive username and active key
 
-5. `docker compose up -d`
+6. `docker compose up -d`
    Start the Docker containers. This will add a GraphQL server on port 8080, a MongoDB instance on port 27021, and a libp2p connection on port 10720.
 
 ### Starting Up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,13 @@ services:
     image: vscnetwork/go-vsc-node:main
     command: ./vsc-node --init
     environment:
-      - MONGO_URL=mongodb://mongo:27017
+      # VD-H1: authenticated MongoDB connection (see mongo service + .env.example).
+      - MONGO_URL=mongodb://${MONGO_USER:-vsc_node}:${MONGO_PASSWORD:?set MONGO_PASSWORD in .env}@mongo:27017/?authSource=admin
+    # Gate init on mongo being healthy too — on a fresh install this avoids
+    # racing mongod's auth bootstrap (the root user is created during init).
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
     networks:
       - go-vsc-node
     volumes:
@@ -36,7 +40,8 @@ services:
       - 10720:10720
       - 10720:10720/udp
     environment:
-      - MONGO_URL=mongodb://mongo:27017
+      # VD-H1: authenticated MongoDB connection (see mongo service + .env.example).
+      - MONGO_URL=mongodb://${MONGO_USER:-vsc_node}:${MONGO_PASSWORD:?set MONGO_PASSWORD in .env}@mongo:27017/?authSource=admin
     volumes:
       - ./data:/home/app/app/data
     logging:
@@ -55,6 +60,14 @@ services:
     image: mongo:8.0.17
     pull_policy: always
     restart: always
+    # VD-H1: enable authentication. On the official image these both create the
+    # root user (on first init of an EMPTY data dir) and enable --auth, so the
+    # DB is no longer open to anything that can reach it.
+    # NOTE: these only initialise a FRESH ./data/vsc-db; an existing un-authed
+    # volume needs the user created once manually (see README "Upgrading").
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_USER:-vsc_node}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:?set MONGO_PASSWORD in .env}
     ports:
       - 127.0.0.1:27021:27017
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,14 @@ services:
     pull_policy: always
     container_name: go-vsc-node # what to label the container for docker ps
     restart: always # restart if failed, until we stop it ourselves
+    # VD-L-BTCDHEALTH: gate startup on mongo AND btcd being healthy (both now
+    # have healthchecks), so the node never boots against a not-ready DB or a
+    # btcd that is still bringing up RPC.
     depends_on:
-      - mongo
-      - btcd
+      mongo:
+        condition: service_healthy
+      btcd:
+        condition: service_healthy
     networks:
       - go-vsc-node
     ports:
@@ -61,6 +66,11 @@ services:
       interval: 10s
       retries: 5
       timeout: 5s
+      # AF-2: now that go-vsc-node and init wait on `mongo: service_healthy`,
+      # give mongod room for cold-boot journal replay before the gate trips.
+      # Without this, a replay longer than interval*retries (~50s) would brick
+      # cold boot.
+      start_period: 60s
     logging:
       driver: "json-file"
       options:
@@ -88,6 +98,24 @@ services:
     container_name: vsc-btcd
     command: -rpcuser=vsc-node-user -rpcpassword=vsc-node-pass -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0 -prune=550 -dbcache=2048 -server=1 -listen=1
     restart: always
+    # NOTE: the -rpcuser / -rpcpassword in the healthcheck below MUST stay in
+    # sync with the -rpcuser / -rpcpassword in `command:` above (and in
+    # multi-core-docker-compose.yml). If the BTC RPC credentials are rotated
+    # (see CRIT-6 remediation), update ALL places in the same commit or the
+    # healthcheck 401s and go-vsc-node never starts (it waits on
+    # btcd: condition: service_healthy). getblockchaininfo responds during IBD,
+    # so the gate passes on RPC-up — no deadlock while the chain syncs.
+    healthcheck:
+      test:
+        - "CMD"
+        - "bitcoin-cli"
+        - "-rpcuser=vsc-node-user"
+        - "-rpcpassword=vsc-node-pass"
+        - "getblockchaininfo"
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
     volumes:
       - ./.btc-data:/home/bitcoin/.bitcoin
     logging:

--- a/multi-core-docker-compose.yml
+++ b/multi-core-docker-compose.yml
@@ -1,0 +1,27 @@
+# Multi-core btcd override (from PR #12, brianoflondon).
+#
+# Speeds up the initial Bitcoin block-chain sync on machines with several
+# cores by raising btcd's UTXO cache (-dbcache) and pinning its script-
+# verification thread count (-par). brianoflondon measured -par=8 taking btcd
+# from ~1 core / 167 blk/s to ~5 cores / 199 blk/s on his host.
+#
+# This is an OVERRIDE, not a standalone stack — it only changes btcd's
+# `command:`. Everything else (Mongo auth, healthchecks, service_healthy
+# gates, the VD-M3 loopback bind, image pins) is inherited from
+# docker-compose.yml, so the two files can never drift out of sync.
+#
+# The -rpcuser / -rpcpassword here MUST match docker-compose.yml's btcd
+# command, otherwise the btcd healthcheck (which authenticates with those
+# creds) 401s and go-vsc-node never starts. They are identical to the base
+# on purpose — only -dbcache and -par differ.
+#
+# Usage (note BOTH -f flags, base first):
+#   docker compose -f docker-compose.yml -f multi-core-docker-compose.yml up -d
+#
+# Tune -par / -dbcache to your machine. -par = script-verification threads
+# (0 = auto up to 15, negative = leave that many cores free, default 0);
+# pinning it helps because in-container CPU auto-detection often under-counts
+# the available cores. -dbcache is the UTXO cache in MiB (bitcoind default 450).
+services:
+  btcd:
+    command: -rpcuser=vsc-node-user -rpcpassword=vsc-node-pass -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0 -prune=550 -dbcache=4096 -par=8 -server=1 -listen=1


### PR DESCRIPTION
Supersedes and combines the three open deployment PRs onto current `main`, with
the review findings on each one fixed. Replaces #12, #15, #17 — close those in
favour of this.

| Source | Included | Fixes applied here |
|---|---|---|
| **#12** (multi-core btcd sync) | `multi-core-docker-compose.yml` | Reworked from a full standalone duplicate into a **thin override** (only overrides btcd `command:` → `-par=8 -dbcache=4096`); used via `-f docker-compose.yml -f multi-core-docker-compose.yml`. Auth/healthchecks/images now inherit from the base and can't drift. (`version:` removal already in `main`.) |
| **#15** (btcd healthcheck + gates) | btcd `getblockchaininfo` healthcheck, go-vsc-node `depends_on: service_healthy` (mongo+btcd), mongo `start_period` (AF-2), Incident Response runbook | **Added the Incident Response section that #15's description claimed but never committed** (VD-L-README). |
| **#17** (VD-H1 Mongo auth) | mongo root creds, credentialed `MONGO_URL`, `.env.example`, README setup/upgrade steps | createUser now uses `MONGO_INITDB_ROOT_*` (the host-side `MONGO_USER/PASSWORD` don't exist in-container → old command failed); `.env.example` warns password must be URL-safe; `init` gated on `mongo: service_healthy`. |

### Notes
- 4 single-purpose commits (one per change above), so it reviews cleanly.
- Mongo `MONGO_PASSWORD` uses compose's `:?` form — **no insecure default**; compose refuses to start unset.

### Verified
- `docker compose config -q` passes for base **and** the `-f` override.
- Ran the healthchecks live on the pinned images: btcd `getblockchaininfo` healthy in ~6s; mongo `ping` healthcheck returns ok under `--auth` (no deadlock); auth enforced after init (`listDatabases` rejected unauth) and the documented upgrade `createUser` bootstraps via the localhost exception.

### Deploy
Operators must `git pull` + `docker compose down && docker compose up -d` (watchtower does not deliver compose changes). Set `MONGO_PASSWORD` in `.env` first.
